### PR TITLE
Make Kid3 flatpak work, update to version 3.8.3

### DIFF
--- a/org.kde.Kid3.metainfo.xml
+++ b/org.kde.Kid3.metainfo.xml
@@ -26,7 +26,7 @@
   </screenshots>
 
   <releases>
-    <release version="3.8.2" date="2012-01-23">
+    <release version="3.8.3" date="2020-05-10">
       <description>
         <p>First release of Kid3 on Flathub.</p>
       </description>

--- a/org.kde.Kid3.yaml
+++ b/org.kde.Kid3.yaml
@@ -4,13 +4,12 @@ runtime-version: "5.14"
 sdk: org.kde.Sdk
 command: kid3
 
-#rename-desktop-file: flacon.desktop
-#rename-icon: flacon
-
 finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=x11
+  - --socket=pulseaudio
+  - --socket=session-bus
   - --share=ipc
   - --device=dri
 
@@ -18,70 +17,55 @@ finish-args:
   - --share=network
 
   # Required for input-output
-  # Flacon uses some advanced file scanning techniques
-  # not compatible with portals
   - --filesystem=xdg-download
   - --filesystem=xdg-music
   - --env=TMPDIR=/var/tmp
+
+  # For MPRIS
+  - --own-name=org.mpris.MediaPlayer2.kid3
 
 cleanup:
   - /man
   - /include
   - /share/man
-  - /share/doc
   - /include
   - /lib/*.a
   - /lib/*.la
 
 modules:
-
-# Not sure yet how to make the docbook work, might require upstream work
-# to make it build differently.
-# - name: xpath
-#   buildsystem: simple
-#   build-commands:
-#     - perl Makefile.PL
-#     - make
-#     - make install DESTDIR=/app
-#   sources:
-#     - type: archive
-#       url: https://github.com/manwar/XML-XPath/archive/v1.44.tar.gz
-#       sha256: 19d5318eaba8434ea529c6bd8eb98947c451ce86f4f595b55b463fc70a480c3c
-      
-# - name: docbook
-#   buildsystem: simple
-#   build-commands:
-#     - make
-#   sources:
-#     - type: archive
-#       url: https://github.com/docbook/xslt10-stylesheets/archive/snapshot/2019-10-05-bobs.tar.gz
-#       sha256: 27d3893d6f974204273f70c9261327915fd27a33d77ecaf1208c8e4bf63310c4
-
 - name: chromaprint
   buildsystem: cmake-ninja
   config-opts:
   - -DCMAKE_BUILD_TYPE=RelWithDebInfo
   sources:
     - type: archive
-      url: https://github.com/acoustid/chromaprint/archive/v1.4.3.tar.gz
-      sha256: d4ae6596283aad7a015a5b0445012054c634a4b9329ecb23000cd354b40a283b
+      url: https://github.com/acoustid/chromaprint/archive/v1.5.0.tar.gz
+      sha256: 5c8e0d579cb3478900699110aa961c1552a422a18741cf67dd62136b1b877c7b
 
-- name: id3lib
-  buildsystem: autotools
+- name: taglib
+  buildsystem: cmake-ninja
+  config-opts:
+  - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  - -DBUILD_SHARED_LIBS=ON
+  - -DWITH_MP4=ON
+  - -DWITH_ASF=ON
   sources:
     - type: archive
-      url: http://download.sourceforge.net/id3lib/id3lib-3.8.3.tar.gz
-      sha256: 2749cc3c0cd7280b299518b1ddf5a5bcfe2d1100614519b68702230e26c7d079
+      url: https://taglib.org/releases/taglib-1.11.1.tar.gz
+      sha256: b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b
 
 - name: kid3
   buildsystem: cmake-ninja
   config-opts:
   - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-  - -WITH_APPS="Qt;CLI"
-  # This sidesteps the docs requirement for the time being
-  - -DDOCBOOK_XSL_DIR=/app/usr/docs
+  - -DWITH_APPS=KDE;Qt;CLI
+  - -DWITH_ID3LIB=OFF
+  - -DDOCBOOK_XSL_DIR=docbook-xsl
   sources:
     - type: archive
-      url: https://invent.kde.org/kde/kid3/-/archive/v3.8.2/kid3-v3.8.2.tar.gz
-      sha256: f1800fe9a491078e5f362215d0e2568be8b404ad99f6b86d17774cedb9d1ef9e
-
+      url: https://invent.kde.org/kde/kid3/-/archive/v3.8.3/kid3-v3.8.3.tar.gz
+      sha256: 8e9a755e810b5e28f36ab2b46b68ba77d910341d208f939ce58c3d2ca91d06c9
+    - type: archive
+      dest: docbook-xsl
+      url: https://github.com/docbook/xslt10-stylesheets/releases/download/release/1.79.2/docbook-xsl-1.79.2.tar.gz
+      sha256: 966188d7c05fc76eaca115a55893e643dd01a3486f6368733c9ad974fcee7a26


### PR DESCRIPTION
I extracted docbook-xsl to build directory and removed id3lib to make the build work. I added TagLib, which is the main tagging library used by Kid3. Other small changes add support for audio and the MPRIS interface.